### PR TITLE
Fix PHP cleanup configuration file handling

### DIFF
--- a/wt/main.sh
+++ b/wt/main.sh
@@ -95,7 +95,8 @@ cleanup() {
   systemctl disable "${SYSTEMD_UNIT}" || true
   systemctl daemon-reload
 
-  rm -f "${PHP_MASTER_CONF}" "${PHP_LOG_DIR}"
+  rm -f "${PHP_MASTER_CONF_FILE}"
+  rm -rf "${PHP_LOG_DIR}"
   rm -f "${NGINXROOT}/sites-enabled/${DOMAIN}" \
         "${NGINXROOT}/sites-available/${DOMAIN}"
   rm -f "${NGINXROOT}/conf.d/upstream-${SLUG}.conf" \


### PR DESCRIPTION
## Summary
- fix cleanup variable name for PHP-FPM master config
- remove PHP log directory recursively

## Testing
- `flake8`
- `nosetests tests` *(fails: AttributeError: module 'collections' has no attribute 'Callable')*

------
https://chatgpt.com/codex/tasks/task_e_68644052fe74832195ce14686d8a3852