### PR TITLE
Fix template path argument usage

### DIFF
--- a/wt/main.sh
+++ b/wt/main.sh
@@ -180,7 +180,7 @@ export \
   SELFSIGNCERT_ROOT
 
 if [[ ! -f "${PHP_FPM_SYSTEMD_TPL}" ]]; then
-  run_render '${PHPVER}' < "${TEMPLATE_DIR}/php-fpm-systemd.tpl" "${PHP_FPM_SYSTEMD_TPL}"
+  run_render '${PHPVER}' "${TEMPLATE_DIR}/php-fpm-systemd.tpl" "${PHP_FPM_SYSTEMD_TPL}"
 fi
 
 # 8) Write the per-site PHP-FPM global config


### PR DESCRIPTION
## Summary
- correct the first `run_render` call to pass the template path normally

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864405876f08321892de45c98c20ed1