### PR TITLE
Fix template directory lookup

### DIFF
--- a/wt/main.sh
+++ b/wt/main.sh
@@ -62,7 +62,7 @@ LOG_DIR="${WEBROOT}/logs"
 WPCLI_USER="wpcli-${SLUG}"
 
 SELFSIGNCERT_ROOT="/etc/ssl/selfsigned"
-TEMPLATE_DIR="/home"
+TEMPLATE_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # 1) Must be root
 if (( EUID != 0 )); then


### PR DESCRIPTION
## Summary
- stop hardcoding template folder
- use the script's location to locate template files

## Testing
- `pytest -q tests/cli/13_test_stack_install.py -k 'test' -q` *(fails: ModuleNotFoundError: No module named 'cement')*

------
https://chatgpt.com/codex/tasks/task_e_686440a87ae88321b71d6048c308c0dd