### PR TITLE
Add slug-specific auth variable for secure plugin

### DIFF
--- a/tests/cli/28_test_secure.py
+++ b/tests/cli/28_test_secure.py
@@ -23,8 +23,8 @@ class CliTestCaseSecure(TestCase):
                 with WOTestApp(argv=['secure', '--domain', 'example.com', 'user', 'pass']) as app:
                     secure_mod.load(app)
                     app.run()
-                    mock_map.assert_called_with('/etc/nginx/sites-available/example.com', ['~^/wp-login\\.php     1;', '~^/wp-admin/         1;'])
-                    mock_acl.assert_called_with('/etc/nginx/sites-available/example.com', 'example-com')
+                    mock_map.assert_called_with('/etc/nginx/sites-available/example.com', ['~^/wp-login\\.php     1;', '~^/wp-admin/         1;'], 'require_auth_example_com')
+                    mock_acl.assert_called_with('/etc/nginx/sites-available/example.com', 'example-com', 'require_auth_example_com')
 
     def test_secure_domain_whitelist(self):
         fake_site_funcs = mock.Mock()
@@ -44,5 +44,5 @@ class CliTestCaseSecure(TestCase):
                 with WOTestApp(argv=['secure', '--domain', 'example.com', '--path', '/admin', 'user', 'pass']) as app:
                     secure_mod.load(app)
                     app.run()
-                    mock_map.assert_called_with('/etc/nginx/sites-available/example.com', ['~^/admin     1;'])
-                    mock_acl.assert_called_with('/etc/nginx/sites-available/example.com', 'example-com')
+                    mock_map.assert_called_with('/etc/nginx/sites-available/example.com', ['~^/admin     1;'], 'require_auth_example_com')
+                    mock_acl.assert_called_with('/etc/nginx/sites-available/example.com', 'example-com', 'require_auth_example_com')


### PR DESCRIPTION
## Summary
- generate slug-scoped `require_auth_<slug>` variable for Nginx basic auth
- update map, ACL, and clear routines to use and remove slug-specific variable
- adjust secure CLI tests for new variable name

## Testing
- `pytest tests/cli/28_test_secure.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892bdad605c8321a1caccdde4e53a3b