### PR TITLE
Remove htpasswd file when clearing ACL

### DIFF
--- a/tests/cli/28_test_secure.py
+++ b/tests/cli/28_test_secure.py
@@ -46,3 +46,31 @@ class CliTestCaseSecure(TestCase):
                     app.run()
                     mock_map.assert_called_with('/etc/nginx/sites-available/example.com', ['~^/admin     1;'])
                     mock_acl.assert_called_with('/etc/nginx/sites-available/example.com', 'example-com')
+
+    def test_clear_acl_removes_htpasswd_and_commits(self):
+        fake_site_funcs = mock.Mock()
+        with mock.patch.dict('sys.modules', {
+            'apt': mock.Mock(),
+            'wo.cli.plugins.site_functions': fake_site_funcs,
+        }):
+            secure_mod = importlib.reload(importlib.import_module('wo.cli.plugins.secure'))
+            vhost_path = '/etc/nginx/sites-available/example.com'
+            slug = 'example-com'
+            htpasswd_path = f'/etc/nginx/acls/htpasswd-{slug}'
+            vhost_content = (
+                'map $uri $require_auth {\n' '    default              1;\n' '}\n'
+                '# acl start\n'
+                '    auth_basic           "Restricted"      if=$require_auth;\n'
+                '    auth_basic_user_file /etc/nginx/acls/htpasswd-example-com  if=$require_auth;\n'
+                '# acl end\n'
+            )
+            with mock.patch.object(secure_mod.os.path, 'exists', side_effect=lambda p: p in [vhost_path, htpasswd_path]), \
+                 mock.patch('builtins.open', mock.mock_open(read_data=vhost_content)), \
+                 mock.patch.object(secure_mod.os, 'remove') as mock_remove, \
+                 mock.patch.object(secure_mod.WOGit, 'add') as mock_git_add, \
+                 mock.patch.object(secure_mod.WOService, 'reload_service', return_value=True):
+                with WOTestApp(argv=['secure', '--domain', 'example.com', '--clear']) as app:
+                    secure_mod.load(app)
+                    app.run()
+                    mock_remove.assert_called_with(htpasswd_path)
+                    mock_git_add.assert_called_with(mock.ANY, ['/etc/nginx'], msg='Removed basic auth for example.com')

--- a/wo/cli/plugins/secure.py
+++ b/wo/cli/plugins/secure.py
@@ -159,9 +159,14 @@ class WOSecureController(CementBaseController):
 
         with open(vhost_path, 'w', encoding='utf-8') as f:
             f.writelines(new_lines)
-        Log.info(self, f"Removed basic auth for {wo_domain}")
+        slug = wo_domain.replace('.', '-').lower()
+        htpasswd_file = os.path.join('/etc/nginx/acls', f'htpasswd-{slug}')
+        if os.path.exists(htpasswd_file):
+            os.remove(htpasswd_file)
+        WOGit.add(self, ['/etc/nginx'], msg=f"Removed basic auth for {wo_domain}")
         if not WOService.reload_service(self, 'nginx'):
             Log.error(self, "service nginx reload failed. check `nginx -t`")
+        Log.info(self, f"Removed basic auth for {wo_domain}")
 
     def _update_map_block(self, vhost_path, entries):
         """Insert map block at top of vhost"""


### PR DESCRIPTION
## Summary
- delete htpasswd file when clearing basic auth
- track Nginx config changes when removing ACL
- test ACL clearing removes htpasswd and commits

## Testing
- `pytest tests/cli/28_test_secure.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892bde079048321b5756ea325372a10