### PR TITLE
feat: manage nginx basic auth via templates

### DIFF
--- a/tests/cli/28_test_secure.py
+++ b/tests/cli/28_test_secure.py
@@ -5,7 +5,7 @@ import importlib
 
 class CliTestCaseSecure(TestCase):
 
-    def test_secure_domain_password(self):
+    def test_secure_domain_renders_protected(self):
         fake_site_funcs = mock.Mock()
         fake_site_funcs.getSiteInfo = mock.Mock()
         with mock.patch.dict('sys.modules', {
@@ -13,21 +13,27 @@ class CliTestCaseSecure(TestCase):
             'wo.cli.plugins.site_functions': fake_site_funcs,
         }):
             secure_mod = importlib.reload(importlib.import_module('wo.cli.plugins.secure'))
-            with mock.patch.object(secure_mod.WOShellExec, 'cmd_exec'), \
+            with mock.patch.object(secure_mod.WOShellExec, 'cmd_exec') as mock_exec, \
                  mock.patch.object(secure_mod.WOService, 'reload_service', return_value=True), \
-                 mock.patch.object(secure_mod.WOGit, 'add'), \
+                 mock.patch.object(secure_mod.WOGit, 'add') as mock_git_add, \
                  mock.patch.object(secure_mod.os, 'makedirs'), \
-                 mock.patch.object(secure_mod.WOSecureController, '_update_map_block') as mock_map, \
-                 mock.patch.object(secure_mod.WOSecureController, '_insert_acl_block') as mock_acl:
-                fake_site_funcs.getSiteInfo.return_value = mock.Mock(site_path='/var/www/example.com', site_type='wp')
+                 mock.patch.object(secure_mod.WOTemplate, 'deploy') as mock_deploy:
+                fake_site_funcs.getSiteInfo.return_value = mock.Mock(site_path='/var/www/example.com', site_type='wp', php_version='8.1')
                 with WOTestApp(argv=['secure', '--domain', 'example.com', 'user', 'pass']) as app:
                     secure_mod.load(app)
                     app.run()
+                    expected_data = {
+                        'slug': 'example-com',
+                        'secure': True,
+                        'wp': True,
+                        'php_ver': '81',
+                        'pool_name': 'example-com',
+                    }
+                    mock_deploy.assert_called_with(mock.ANY, '/etc/nginx/acl/example-com/protected.conf', 'protected.mustache', expected_data, overwrite=True)
+                    mock_exec.assert_called()
+                    mock_git_add.assert_called_with(mock.ANY, ['/etc/nginx'], msg='Secured example.com with basic auth')
 
-                    mock_map.assert_called_with('/etc/nginx/sites-available/example.com', ['~^/wp-login\.php     1;', '~^/wp-admin/         1;'], 'require_auth_example_com')
-                    mock_acl.assert_called_with('/etc/nginx/sites-available/example.com', 'example-com', 'require_auth_example_com')
-
-    def test_secure_domain_whitelist(self):
+    def test_clear_acl_removes_credentials_and_rerenders(self):
         fake_site_funcs = mock.Mock()
         fake_site_funcs.getSiteInfo = mock.Mock()
         with mock.patch.dict('sys.modules', {
@@ -35,46 +41,23 @@ class CliTestCaseSecure(TestCase):
             'wo.cli.plugins.site_functions': fake_site_funcs,
         }):
             secure_mod = importlib.reload(importlib.import_module('wo.cli.plugins.secure'))
-            with mock.patch.object(secure_mod.WOShellExec, 'cmd_exec'), \
-                 mock.patch.object(secure_mod.WOService, 'reload_service', return_value=True), \
-                 mock.patch.object(secure_mod.WOGit, 'add'), \
-                 mock.patch.object(secure_mod.os, 'makedirs'), \
-                 mock.patch.object(secure_mod.WOSecureController, '_update_map_block') as mock_map, \
-                 mock.patch.object(secure_mod.WOSecureController, '_insert_acl_block') as mock_acl:
-                fake_site_funcs.getSiteInfo.return_value = mock.Mock(site_path='/var/www/example.com', site_type='html')
-                with WOTestApp(argv=['secure', '--domain', 'example.com', '--path', '/admin', 'user', 'pass']) as app:
-                    secure_mod.load(app)
-                    app.run()
-                    mock_map.assert_called_with('/etc/nginx/sites-available/example.com', ['~^/admin     1;'])
-                    mock_acl.assert_called_with('/etc/nginx/sites-available/example.com', 'example-com')
-
-    def test_clear_acl_removes_htpasswd_and_commits(self):
-        fake_site_funcs = mock.Mock()
-        with mock.patch.dict('sys.modules', {
-            'apt': mock.Mock(),
-            'wo.cli.plugins.site_functions': fake_site_funcs,
-        }):
-            secure_mod = importlib.reload(importlib.import_module('wo.cli.plugins.secure'))
-            vhost_path = '/etc/nginx/sites-available/example.com'
-            slug = 'example-com'
-            htpasswd_path = f'/etc/nginx/acls/htpasswd-{slug}'
-            vhost_content = (
-                'map $uri $require_auth {\n' '    default              1;\n' '}\n'
-                '# acl start\n'
-                '    auth_basic           "Restricted"      if=$require_auth;\n'
-                '    auth_basic_user_file /etc/nginx/acls/htpasswd-example-com  if=$require_auth;\n'
-                '# acl end\n'
-            )
-            with mock.patch.object(secure_mod.os.path, 'exists', side_effect=lambda p: p in [vhost_path, htpasswd_path]), \
-                 mock.patch('builtins.open', mock.mock_open(read_data=vhost_content)), \
+            credentials = '/etc/nginx/acl/example-com/credentials'
+            with mock.patch.object(secure_mod.os.path, 'exists', return_value=True), \
                  mock.patch.object(secure_mod.os, 'remove') as mock_remove, \
+                 mock.patch.object(secure_mod.WOTemplate, 'deploy') as mock_deploy, \
                  mock.patch.object(secure_mod.WOGit, 'add') as mock_git_add, \
                  mock.patch.object(secure_mod.WOService, 'reload_service', return_value=True):
+                fake_site_funcs.getSiteInfo.return_value = mock.Mock(site_path='/var/www/example.com', site_type='html', php_version='8.1')
                 with WOTestApp(argv=['secure', '--domain', 'example.com', '--clear']) as app:
                     secure_mod.load(app)
                     app.run()
-                    mock_remove.assert_called_with(htpasswd_path)
+                    expected_data = {
+                        'slug': 'example-com',
+                        'secure': False,
+                        'wp': False,
+                        'php_ver': '81',
+                        'pool_name': 'example-com',
+                    }
+                    mock_deploy.assert_called_with(mock.ANY, '/etc/nginx/acl/example-com/protected.conf', 'protected.mustache', expected_data, overwrite=True)
+                    mock_remove.assert_called_with(credentials)
                     mock_git_add.assert_called_with(mock.ANY, ['/etc/nginx'], msg='Removed basic auth for example.com')
-
-                    mock_map.assert_called_with('/etc/nginx/sites-available/example.com', ['~^/admin     1;'], 'require_auth_example_com')
-                    mock_acl.assert_called_with('/etc/nginx/sites-available/example.com', 'example-com', 'require_auth_example_com')

--- a/wo/cli/plugins/stack_pref.py
+++ b/wo/cli/plugins/stack_pref.py
@@ -298,18 +298,27 @@ def post_pref(self, apt_packages, packages, upgrade=False):
                 '/etc/nginx/sites-available/22222',
                 '22222.mustache', data, overwrite=True)
 
+            acl_dir = '/etc/nginx/acl/22222'
+            os.makedirs(acl_dir, exist_ok=True)
+            WOTemplate.deploy(
+                self,
+                f'{acl_dir}/protected.conf',
+                'protected.mustache',
+                dict(data, slug='22222', secure=True, wp=False),
+                overwrite=True)
+
             passwd = ''.join([random.choice
                               (string.ascii_letters + string.digits)
                               for n in range(24)])
-            if not os.path.isfile('/etc/nginx/htpasswd-wo'):
+            cred_path = f'{acl_dir}/credentials'
+            if not os.path.isfile(cred_path):
                 try:
                     WOShellExec.cmd_exec(
                         self, "printf \"WordOps:"
                         "$(openssl passwd -apr1 "
                         "{password} 2> /dev/null)\n\""
-                        "> /etc/nginx/htpasswd-wo "
-                        "2>/dev/null"
-                        .format(password=passwd))
+                        "> {cred} "
+                        "2>/dev/null".format(password=passwd, cred=cred_path))
                 except CommandExecutionError as e:
                     Log.debug(self, "{0}".format(e))
                     Log.error(self, "Failed to save HTTP Auth")

--- a/wo/cli/templates/22222.mustache
+++ b/wo/cli/templates/22222.mustache
@@ -21,7 +21,7 @@ server {
   autoindex on;
 
   # HTTP Authentication on port 22222
-  include common/acl.conf;
+  include /etc/nginx/acl/{{pool_name}}/protected.conf;
 
   # nginx-vts-status
   location /vts_status {

--- a/wo/cli/templates/protected.mustache
+++ b/wo/cli/templates/protected.mustache
@@ -1,0 +1,28 @@
+{{#wp}}
+# Limit access to avoid brute force attack
+location = /wp-login.php {
+  {{#secure}}
+  satisfy any;
+  auth_basic "Restricted Area";
+  auth_basic_user_file /etc/nginx/acl/{{slug}}/credentials;
+  # Allowed IP Address List
+  allow 127.0.0.1;
+  allow ::1;
+  deny all;
+  {{/secure}}
+  limit_req zone=one burst=1 nodelay;
+  include fastcgi_params;
+  fastcgi_pass unix:/run/php/php{{php_ver}}-fpm-{{pool_name}}.sock;
+}
+{{/wp}}
+{{^wp}}
+{{#secure}}
+satisfy any;
+auth_basic "Restricted Area";
+auth_basic_user_file /etc/nginx/acl/{{slug}}/credentials;
+# Allowed IP Address List
+allow 127.0.0.1;
+allow ::1;
+deny all;
+{{/secure}}
+{{/wp}}

--- a/wo/cli/templates/virtualconf.mustache
+++ b/wo/cli/templates/virtualconf.mustache
@@ -17,7 +17,7 @@ server {
     error_log /var/log/nginx/{{site_name}}.error.log;
 
     # acl start
-
+    include /etc/nginx/acl/{{pool_name}}/protected.conf;
     # acl end
 
     {{#alias}}


### PR DESCRIPTION
## Summary
- add `protected.mustache` and include it from vhosts
- rework `wo secure` and `wo site create` to render and toggle basic auth
- update admin stack preferences and tests

## Testing
- `pytest tests/cli/28_test_secure.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894b31ef8788321814a97e29d8a5eeb