### PR TITLE
fix: include php packages in stack purge

### DIFF
--- a/tests/cli/31_test_stack_purge.py
+++ b/tests/cli/31_test_stack_purge.py
@@ -1,5 +1,6 @@
 from wo.utils import test
 from wo.cli.main import WOTestApp
+from unittest.mock import patch
 
 
 class CliTestCaseStackPurge(test.WOTestCase):
@@ -48,3 +49,17 @@ class CliTestCaseStackPurge(test.WOTestCase):
         with WOTestApp(argv=['stack', 'purge',
                                       '--utils', '--force']) as app:
             app.run()
+
+    def test_wo_cli_stack_purge_all_removes_php(self):
+        def fake_is_installed(self, package_name):
+            return package_name == 'php7.4-fpm'
+
+        with patch('wo.core.aptget.WOAptGet.is_installed',
+                   new=fake_is_installed), \
+             patch('wo.core.aptget.WOAptGet.remove') as mock_remove, \
+             patch('wo.core.aptget.WOAptGet.auto_remove'):
+            with WOTestApp(argv=['stack', 'purge', '--all', '--force']) as app:
+                app.run()
+
+        removed = mock_remove.call_args[0][1]
+        assert 'php7.4-fpm' in removed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+import sys
+from types import ModuleType
+
+# Minimal nose stub
+nose = ModuleType('nose')
+class SkipTest(Exception):
+    pass
+nose.SkipTest = SkipTest
+
+# nose.tools
+nose_tools = ModuleType('nose.tools')
+
+def raises(*exc_types):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            try:
+                func(*args, **kwargs)
+            except exc_types:
+                return
+            raise AssertionError('Did not raise')
+        return wrapper
+    return decorator
+
+def ok_(expr, msg=None):
+    if not expr:
+        raise AssertionError(msg or 'expression is not true')
+
+def eq_(a, b, msg=None):
+    if a != b:
+        raise AssertionError(msg or f'{a!r} != {b!r}')
+
+nose_tools.raises = raises
+nose_tools.ok_ = ok_
+nose_tools.eq_ = eq_
+
+# nose.plugins.attrib
+nose_plugins = ModuleType('nose.plugins')
+nose_attrib = ModuleType('nose.plugins.attrib')
+
+def attr(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+nose_attrib.attr = attr
+nose_plugins.attrib = nose_attrib
+
+# register modules
+sys.modules.setdefault('nose', nose)
+sys.modules.setdefault('nose.tools', nose_tools)
+sys.modules.setdefault('nose.plugins', nose_plugins)
+sys.modules.setdefault('nose.plugins.attrib', nose_attrib)
+
+# Minimal apt stub
+apt = ModuleType('apt')
+apt_cache = ModuleType('apt.cache')
+
+class Cache(dict):
+    def open(self):
+        pass
+
+apt_cache.Cache = Cache
+apt.cache = apt_cache
+
+sys.modules.setdefault('apt', apt)
+sys.modules.setdefault('apt.cache', apt_cache)

--- a/wo/cli/plugins/stack.py
+++ b/wo/cli/plugins/stack.py
@@ -951,7 +951,7 @@ class WOStackController(CementBaseController):
         for parg_version, version in WOVar.wo_php_versions.items():
             if getattr(pargs, parg_version, False):
                 Log.debug(self, f"Setting apt_packages variable for PHP {version}")
-                if not WOAptGet.is_installed(self, f'php{version}-fpm'):
+                if WOAptGet.is_installed(self, f'php{version}-fpm'):
                     apt_packages = apt_packages + wo_vars[parg_version]
                 else:
                     Log.debug(self, f"PHP {version} already purged")


### PR DESCRIPTION
## Summary
- ensure php-fpm packages are purged when running `wo stack purge`
- test stack purge against php removal
- stub nose/apt for tests

## Testing
- `pytest -q`
- `pytest tests/cli/31_test_stack_purge.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894d068e1188321b687e921f2c7250d