### PR TITLE
fix php8.4 install conflict with existing FPM service

### DIFF
--- a/wo/cli/plugins/stack.py
+++ b/wo/cli/plugins/stack.py
@@ -828,6 +828,12 @@ class WOStackController(CementBaseController):
                 WOMysql.backupAll(self)
                 WOService.stop_service(self, 'mysql')
 
+            for version in WOVar.wo_php_versions.values():
+                service = f'php{version}-fpm'
+                if service in apt_packages:
+                    WOService.stop_service(self, service)
+                    WOService.stop_service(self, f'{service}@22222')
+
             # Netdata uninstaller
             if '/var/lib/wo/tmp/kickstart.sh' in packages:
                 if os.path.exists(
@@ -1130,6 +1136,12 @@ class WOStackController(CementBaseController):
                             'mysql', 'grant-host') == 'localhost':
                         WOMysql.backupAll(self)
                 WOService.stop_service(self, 'mysql')
+
+            for version in WOVar.wo_php_versions.values():
+                service = f'php{version}-fpm'
+                if service in apt_packages:
+                    WOService.stop_service(self, service)
+                    WOService.stop_service(self, f'{service}@22222')
 
             # Netdata uninstaller
             if '/var/lib/wo/tmp/kickstart.sh' in packages:

--- a/wo/cli/plugins/stack_pref.py
+++ b/wo/cli/plugins/stack_pref.py
@@ -106,6 +106,16 @@ def pre_pref(self, apt_packages):
                 Log.debug(self, 'Adding repo_url of php for debian')
                 Log.info(self, "Adding repository for PHP, please wait...")
                 WORepo.add(self, repo_url=WOVar.wo_php_repo, repo_name="php")
+    # stop existing PHP-FPM service for WordOps backend to avoid socket
+    # conflicts when reinstalling
+    for version in WOVar.wo_php_versions.values():
+        package_name = f'php{version}-fpm'
+        if package_name in apt_packages:
+            service = f'{package_name}@22222'
+            WOShellExec.cmd_exec(self, f'systemctl stop {service}', log=False)
+            sock = f'/run/php/php{version.replace(".", "")}-fpm-22222.sock'
+            if os.path.exists(sock):
+                os.remove(sock)
 
     # add redis repository
     if set(WOVar.wo_redis).issubset(set(apt_packages)):


### PR DESCRIPTION
## Summary
- stop any existing php-fpm@22222 service before installing new PHP packages to prevent socket conflicts
- stop php-fpm services when removing PHP stacks or purging all stacks to prevent lingering sockets

## Testing
- `pytest -q`
- `pytest tests/cli/13_test_stack_install.py -q` *(fails: SystemExit: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6895047a9ce483218df9645aaec963ed