### PR TITLE
Ensure WP-CLI is fully removed during stack purge

### DIFF
--- a/tests/cli/30_test_stack_remove.py
+++ b/tests/cli/30_test_stack_remove.py
@@ -1,5 +1,7 @@
 from wo.utils import test
 from wo.cli.main import WOTestApp
+from unittest.mock import patch
+import os
 
 
 class CliTestCaseStackRemove(test.WOTestCase):
@@ -21,8 +23,30 @@ class CliTestCaseStackRemove(test.WOTestCase):
             app.run()
 
     def test_wo_cli_stack_remove_wpcli(self):
-        with WOTestApp(argv=['stack', 'remove', '--wpcli', '--force']) as app:
-            app.run()
+        orig_isfile = os.path.isfile
+
+        def fake_isfile(path):
+            if path in ['/usr/local/bin/wp', '/usr/bin/wp']:
+                return True
+            return orig_isfile(path)
+
+        def fake_is_installed(self, package_name):
+            return package_name == 'wp-cli'
+
+        with patch('os.path.isfile', side_effect=fake_isfile), \
+             patch('wo.core.aptget.WOAptGet.is_installed',
+                   side_effect=fake_is_installed), \
+             patch('wo.core.aptget.WOAptGet.remove') as mock_remove, \
+             patch('wo.core.aptget.WOAptGet.auto_remove'), \
+             patch('wo.core.fileutils.WOFileUtils.remove') as mock_file_remove:
+            with WOTestApp(argv=['stack', 'remove', '--wpcli', '--force']) as app:
+                app.run()
+
+        removed_pkgs = mock_remove.call_args[0][1]
+        removed_files = mock_file_remove.call_args[0][1]
+        assert 'wp-cli' in removed_pkgs
+        assert '/usr/local/bin/wp' in removed_files
+        assert '/usr/bin/wp' in removed_files
 
     def test_wo_cli_stack_remove_phpmyadmin(self):
         with WOTestApp(argv=['stack', 'remove',

--- a/tests/cli/31_test_stack_purge.py
+++ b/tests/cli/31_test_stack_purge.py
@@ -1,6 +1,7 @@
 from wo.utils import test
 from wo.cli.main import WOTestApp
 from unittest.mock import patch
+import os
 
 
 class CliTestCaseStackPurge(test.WOTestCase):
@@ -31,9 +32,30 @@ class CliTestCaseStackPurge(test.WOTestCase):
             app.run()
 
     def test_wo_cli_stack_purge_wpcli(self):
-        with WOTestApp(argv=['stack', 'purge',
-                                      '--wpcli', '--force']) as app:
-            app.run()
+        orig_isfile = os.path.isfile
+
+        def fake_isfile(path):
+            if path in ['/usr/local/bin/wp', '/usr/bin/wp']:
+                return True
+            return orig_isfile(path)
+
+        def fake_is_installed(self, package_name):
+            return package_name == 'wp-cli'
+
+        with patch('os.path.isfile', side_effect=fake_isfile), \
+             patch('wo.core.aptget.WOAptGet.is_installed',
+                   side_effect=fake_is_installed), \
+             patch('wo.core.aptget.WOAptGet.remove') as mock_remove, \
+             patch('wo.core.aptget.WOAptGet.auto_remove'), \
+             patch('wo.core.fileutils.WOFileUtils.remove') as mock_file_remove:
+            with WOTestApp(argv=['stack', 'purge', '--wpcli', '--force']) as app:
+                app.run()
+
+        removed_pkgs = mock_remove.call_args[0][1]
+        removed_files = mock_file_remove.call_args[0][1]
+        assert 'wp-cli' in removed_pkgs
+        assert '/usr/local/bin/wp' in removed_files
+        assert '/usr/bin/wp' in removed_files
 
     def test_wo_cli_stack_purge_phpmyadmin(self):
         with WOTestApp(

--- a/wo/cli/plugins/stack.py
+++ b/wo/cli/plugins/stack.py
@@ -723,8 +723,11 @@ class WOStackController(CementBaseController):
         # WPCLI
         if pargs.wpcli:
             Log.debug(self, "Removing package variable of WPCLI ")
-            if os.path.isfile('/usr/local/bin/wp'):
-                packages = packages + ['/usr/local/bin/wp']
+            for wp_path in ['/usr/local/bin/wp', '/usr/bin/wp']:
+                if os.path.isfile(wp_path):
+                    packages.append(wp_path)
+            if WOAptGet.is_installed(self, 'wp-cli'):
+                apt_packages.append('wp-cli')
 
         # PHPMYADMIN
         if pargs.phpmyadmin:
@@ -1027,9 +1030,12 @@ class WOStackController(CementBaseController):
 
         # WP-CLI
         if pargs.wpcli:
-            if os.path.isfile('/usr/local/bin/wp'):
-                Log.debug(self, "Purge package variable WPCLI")
-                packages = packages + ['/usr/local/bin/wp']
+            Log.debug(self, "Purge package variable WPCLI")
+            for wp_path in ['/usr/local/bin/wp', '/usr/bin/wp']:
+                if os.path.isfile(wp_path):
+                    packages.append(wp_path)
+            if WOAptGet.is_installed(self, 'wp-cli'):
+                apt_packages.append('wp-cli')
 
         # PHPMYADMIN
         if pargs.phpmyadmin:


### PR DESCRIPTION
## Summary
- ensure `wo stack purge` and `wo stack remove` delete both wp-cli binaries and apt package
- add tests for WP-CLI removal

## Testing
- `pytest -q`
- `pytest tests/cli/31_test_stack_purge.py::CliTestCaseStackPurge::test_wo_cli_stack_purge_wpcli -q` *(fails: SystemExit: 2)*

------
https://chatgpt.com/codex/tasks/task_e_68950f742b888321999bdd9ebd8e78df