### PR TITLE
Fix WordPress clone basic caching flag

### DIFF
--- a/wo/cli/plugins/site_clone.py
+++ b/wo/cli/plugins/site_clone.py
@@ -137,8 +137,9 @@ class WOSiteCloneController(CementBaseController):
 
         if 'wp' in stype:
             data['wp'] = True
-            data['basic'] = False
-            data[cache] = True if cache != 'basic' else False
+            data['basic'] = cache == 'basic'
+            if cache != 'basic':
+                data[cache] = True
             data['multisite'] = stype in ['wpsubdir', 'wpsubdomain']
             if stype == 'wpsubdir':
                 data['wpsubdir'] = True


### PR DESCRIPTION
## Summary
- Ensure `wo site clone` sets `basic` caching flag correctly for WordPress sites without cache plugins
- Only enable cache-specific includes when cloning sites using a cache

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895154f204c8321825175da321b3f12