### PR TITLE
Deploy catch-all default Nginx site

### DIFF
--- a/wo/cli/plugins/stack_pref.py
+++ b/wo/cli/plugins/stack_pref.py
@@ -282,6 +282,20 @@ def post_pref(self, apt_packages, packages, upgrade=False):
                           '/etc/nginx/sites-available')
                 os.makedirs('/etc/nginx/sites-enabled')
 
+            # Default catch-all vhost
+            data = dict()
+            WOTemplate.deploy(self,
+                              '/etc/nginx/sites-available/default',
+                              'catch-all.mustache', data, overwrite=True)
+            if not os.path.islink('/etc/nginx/sites-enabled/default'):
+                WOFileUtils.create_symlink(
+                    self, ['/etc/nginx/'
+                           'sites-available/'
+                           'default',
+                           '/etc/nginx/'
+                           'sites-enabled/'
+                           'default'])
+
             # 22222 port settings
             if os.path.exists('/etc/nginx/sites-available/22222'):
                 Log.debug(self, "looking for the current backend port")


### PR DESCRIPTION
## Summary
- Render new catch-all template to /etc/nginx/sites-available/default
- Ensure default vhost is enabled by creating a sites-enabled symlink

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897813c68c08321bae2fcd78c6d7cfb