### PR TITLE
Fix site clone missing htdocs files

### DIFF
--- a/tests/core/test_fileutils_copyfiles.py
+++ b/tests/core/test_fileutils_copyfiles.py
@@ -1,0 +1,28 @@
+import os
+from wo.core.fileutils import WOFileUtils
+
+class Dummy:
+    class App:
+        class Log:
+            def debug(self, *args, **kwargs):
+                pass
+            def error(self, *args, **kwargs):
+                pass
+            def info(self, *args, **kwargs):
+                pass
+            def warning(self, *args, **kwargs):
+                pass
+        log = Log()
+    app = App()
+
+def test_copyfiles_overwrite(tmp_path):
+    src = tmp_path / "src"
+    dest = tmp_path / "dest"
+    src.mkdir()
+    dest.mkdir()
+    (src / "index.php").write_text("hello")
+    (dest / "old.txt").write_text("old")
+    # ensure destination initially has a different file
+    WOFileUtils.copyfiles(Dummy(), str(src), str(dest), overwrite=True)
+    assert (dest / "index.php").read_text() == "hello"
+    assert not (dest / "old.txt").exists()

--- a/wo/cli/plugins/site_clone.py
+++ b/wo/cli/plugins/site_clone.py
@@ -193,11 +193,9 @@ class WOSiteCloneController(CementBaseController):
         )
         WOShellExec.cmd_exec(self, import_cmd)
 
-        src_root = os.path.join(WOVar.wo_webroot, src, 'htdocs/')
-        dest_root = os.path.join(WOVar.wo_webroot, dest, 'htdocs/')
-
-        WOFileUtils.rm(self, dest_root)
-        WOFileUtils.copyfiles(self, src_root.rstrip('/'), dest_root.rstrip('/'))
+        src_root = os.path.join(WOVar.wo_webroot, src, 'htdocs')
+        dest_root = os.path.join(WOVar.wo_webroot, dest, 'htdocs')
+        WOFileUtils.copyfiles(self, src_root, dest_root, overwrite=True)
 
         # generate new wp-config.php
         setupwordpress(self, data, vhostonly=True)

--- a/wo/core/fileutils.py
+++ b/wo/core/fileutils.py
@@ -61,19 +61,24 @@ class WOFileUtils():
             Log.debug(self, "{0}".format(e))
             Log.error(self, "Unable to reomove symbolic link ...\n")
 
-    def copyfiles(self, src, dest):
+    def copyfiles(self, src, dest, overwrite=False):
         """
         Copies files:
             src : source path
             dest : destination path
+            overwrite : replace destination if it already exists
 
             Recursively copy an entire directory tree rooted at src.
-            The destination directory, named by dst, must not already exist;
-            it will be created as well as missing parent directories.
+            The destination directory, named by dst, will be created as
+            well as missing parent directories. If ``overwrite`` is True
+            and the destination exists it will be replaced to avoid
+            ``copytree`` failures when cloning sites.
         """
         try:
             Log.debug(self, "Copying files, Source:{0}, Dest:{1}"
                       .format(src, dest))
+            if overwrite and os.path.exists(dest):
+                shutil.rmtree(dest)
             shutil.copytree(src, dest)
         except shutil.Error as e:
             Log.debug(self, "{0}".format(e))


### PR DESCRIPTION
## Summary
- ensure `wo site clone` copies htdocs from source to destination
- allow overwriting existing folders in file utils copy helper
- add regression test for copyfiles overwrite behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a60cba208321b953e409ce01189f