### PR TITLE
Refine WordPress template provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ wo site create example.com --wpredis           # install wordpress + nginx redis
 wo site create example.com --wprocket          # install wordpress with WP-Rocket plugin
 wo site create example.com --wpce              # install wordpress with Cache-enabler plugin
 wo site create example.com --wpsc              # install wordpress with wp-super-cache plugin
+wo site create example.com --wp --template docs/examples/wp-template.json  # install wordpress and apply the provisioning template
 ```
 
 ### WordPress multisite with subdirectory
@@ -102,6 +103,7 @@ wo site create example.com --wpsubdir --wpfc     # install wpmu-subdirectory + n
 wo site create example.com --wpsubdir --wpredis  # install wpmu-subdirectory + nginx redis_cache
 wo site create example.com --wpsubdir --wprocket # install wpmu-subdirectory + WP-Rocket plugin
 wo site create example.com --wpsubdir --wpce     # install wpmu-subdirectory + Cache-Enabler plugin
+wo site create example.com --wpsubdir --template docs/examples/wp-template.json  # install wpmu-subdirectory site using the provisioning template
 ```
 
 ### WordPress multisite with subdomain
@@ -113,6 +115,7 @@ wo site create example.com --wpsubdomain --wpfc     # install wpmu-subdomain + n
 wo site create example.com --wpsubdomain --wpredis  # install wpmu-subdomain + nginx redis_cache
 wo site create example.com --wpsubdomain --wprocket # install wpmu-subdomain + WP-Rocket plugin
 wo site create example.com --wpsubdomain --wpce     # install wpmu-subdomain + Cache-Enabler plugin
+wo site create example.com --wpsubdomain --template docs/examples/wp-template.json  # install wpmu-subdomain site using the provisioning template
 ```
 
 ### Non-WordPress sites

--- a/docs/examples/wp-template.json
+++ b/docs/examples/wp-template.json
@@ -1,0 +1,45 @@
+{
+  "themes": [
+    {
+      "slug": "astra",
+      "activate": true
+    }
+  ],
+  "plugins": [
+    {
+      "slug": "nginx-helper",
+      "activate": true,
+      "network": true,
+      "options": {
+        "rt_wp_nginx_helper_options": {
+          "enable_purge": 1,
+          "cache_method": "enable_redis",
+          "redis_hostname": "127.0.0.1",
+          "redis_port": "6379",
+          "redis_prefix": "nginx-cache:"
+        }
+      }
+    },
+    {
+      "slug": "cache-enabler",
+      "activate": true,
+      "options": {
+        "cache-enabler": {
+          "cache_expires": 24,
+          "compress_cache": 1,
+          "minify_html": 1,
+          "minify_inline_css_js": 1
+        }
+      }
+    }
+  ],
+  "options": {
+    "blogname": "Example Inc.",
+    "timezone_string": "America/New_York"
+  },
+  "constants": {
+    "WP_CACHE": true,
+    "WP_MEMORY_LIMIT": "256M",
+    "WP_MAX_MEMORY_LIMIT": "512M"
+  }
+}


### PR DESCRIPTION
## Summary
- add a --template flag to `wo site create` so users can provide a JSON WordPress template
- implement template loading, validation, and execution to install themes, plugins, options, and constants in order, including slug/URL sources and stricter boolean handling
- update WordPress command helpers to support flag options and optional activation logic, and document usage with an example template

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'pkg_resources')*


------
https://chatgpt.com/codex/tasks/task_e_68debc764dd08321bdc57c810575f222